### PR TITLE
Renamed Mappers and re-formatted definition of the dependencies

### DIFF
--- a/cache/src/main/java/com/alexzh/imbarista/cache/SharedPreferencesRepository.kt
+++ b/cache/src/main/java/com/alexzh/imbarista/cache/SharedPreferencesRepository.kt
@@ -4,15 +4,15 @@ import android.content.SharedPreferences
 import com.alexzh.data.model.MapEntity
 import com.alexzh.data.model.SessionEntity
 import com.alexzh.data.repository.PreferencesRepository
-import com.alexzh.imbarista.cache.mapper.MapMapper
-import com.alexzh.imbarista.cache.mapper.SessionMapper
+import com.alexzh.imbarista.cache.mapper.MapCacheMapper
+import com.alexzh.imbarista.cache.mapper.SessionCacheMapper
 import com.alexzh.imbarista.cache.model.Map
 import com.alexzh.imbarista.cache.model.Session
 
 class SharedPreferencesRepository(
     private val prefs: SharedPreferences,
-    private val sessionMapper: SessionMapper,
-    private val mapMapper: MapMapper
+    private val sessionCacheMapper: SessionCacheMapper,
+    private val mapCacheMapper: MapCacheMapper
 ) : PreferencesRepository {
 
     companion object {
@@ -53,7 +53,7 @@ class SharedPreferencesRepository(
 
     override fun getMapProvider(): MapEntity {
         val mapValue = prefs.getString(MAP_PROVIDER, STR_DEFAULT_VALUE) as String
-        return mapMapper.mapFromCached(
+        return mapCacheMapper.mapFromCached(
             if (mapValue.isBlank())
                 Map.TOMTOM
             else
@@ -62,7 +62,7 @@ class SharedPreferencesRepository(
     }
 
     override fun getSessionInfo(): SessionEntity {
-        return sessionMapper.mapFromCached(
+        return sessionCacheMapper.mapFromCached(
             Session(
                 prefs.getLong(SESSION_ID, LONG_DEFAULT_VALUE),
                 prefs.getString(ACCESS_TOKEN, STR_DEFAULT_VALUE) as String,
@@ -74,7 +74,7 @@ class SharedPreferencesRepository(
     }
 
     override fun saveSessionInfo(sessionEntity: SessionEntity) {
-        val session = sessionMapper.mapToCached(sessionEntity)
+        val session = sessionCacheMapper.mapToCached(sessionEntity)
         prefs.edit()
             .putLong(SESSION_ID, session.sessionId)
             .putString(ACCESS_TOKEN, session.accessToken)

--- a/cache/src/main/java/com/alexzh/imbarista/cache/mapper/MapCacheMapper.kt
+++ b/cache/src/main/java/com/alexzh/imbarista/cache/mapper/MapCacheMapper.kt
@@ -3,7 +3,7 @@ package com.alexzh.imbarista.cache.mapper
 import com.alexzh.data.model.MapEntity
 import com.alexzh.imbarista.cache.model.Map
 
-class MapMapper : CachedMapper<Map, MapEntity> {
+class MapCacheMapper : CachedMapper<Map, MapEntity> {
 
     override fun mapFromCached(cacheModel: Map): MapEntity {
         return MapEntity.valueOf(cacheModel.name)

--- a/cache/src/main/java/com/alexzh/imbarista/cache/mapper/SessionCacheMapper.kt
+++ b/cache/src/main/java/com/alexzh/imbarista/cache/mapper/SessionCacheMapper.kt
@@ -3,7 +3,7 @@ package com.alexzh.imbarista.cache.mapper
 import com.alexzh.data.model.SessionEntity
 import com.alexzh.imbarista.cache.model.Session
 
-class SessionMapper : CachedMapper<Session, SessionEntity> {
+class SessionCacheMapper : CachedMapper<Session, SessionEntity> {
 
     override fun mapFromCached(cacheModel: Session): SessionEntity {
         return SessionEntity(

--- a/cache/src/test/java/com/alexzh/imbarista/cache/SharedPreferencesRepositoryTest.kt
+++ b/cache/src/test/java/com/alexzh/imbarista/cache/SharedPreferencesRepositoryTest.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import android.preference.PreferenceManager
 import androidx.test.core.app.ApplicationProvider
 import com.alexzh.data.model.SessionEntity
-import com.alexzh.imbarista.cache.mapper.MapMapper
-import com.alexzh.imbarista.cache.mapper.SessionMapper
+import com.alexzh.imbarista.cache.mapper.MapCacheMapper
+import com.alexzh.imbarista.cache.mapper.SessionCacheMapper
 import com.alexzh.testdata.data.GenerateDataTestData.generateSessionEntity
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -16,8 +16,8 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class SharedPreferencesRepositoryTest {
 
-    private val sessionMapper = SessionMapper()
-    private val mapMapper = MapMapper()
+    private val sessionMapper = SessionCacheMapper()
+    private val mapMapper = MapCacheMapper()
     private val context = ApplicationProvider.getApplicationContext<Context>()
     private val prefs = PreferenceManager.getDefaultSharedPreferences(context)
     private val repository = SharedPreferencesRepository(prefs, sessionMapper, mapMapper)

--- a/cache/src/test/java/com/alexzh/imbarista/cache/mapper/SessionCacheMapperTest.kt
+++ b/cache/src/test/java/com/alexzh/imbarista/cache/mapper/SessionCacheMapperTest.kt
@@ -7,9 +7,9 @@ import com.alexzh.testdata.data.GenerateDataTestData.generateSessionEntity
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-class SessionMapperTest {
+class SessionCacheMapperTest {
 
-    private val mapper = SessionMapper()
+    private val mapper = SessionCacheMapper()
 
     @Test
     fun mapFromEntityToCacheModelCorrectly() {

--- a/data/src/main/java/com/alexzh/data/CoffeeDrinksDataRepository.kt
+++ b/data/src/main/java/com/alexzh/data/CoffeeDrinksDataRepository.kt
@@ -1,6 +1,6 @@
 package com.alexzh.data
 
-import com.alexzh.data.mapper.CoffeeMapper
+import com.alexzh.data.mapper.CoffeeDrinkDataMapper
 import com.alexzh.data.model.HttpDataException
 import com.alexzh.data.repository.CoffeeDrinksCacheRepository
 import com.alexzh.data.store.CoffeeDrinksDataStoreFactory
@@ -10,7 +10,7 @@ import com.alexzh.imbarista.domain.repository.UserRepository
 import io.reactivex.Single
 
 class CoffeeDrinksDataRepository(
-    private val coffeeMapper: CoffeeMapper,
+    private val coffeeDrinkDataMapper: CoffeeDrinkDataMapper,
     private val cacheRepository: CoffeeDrinksCacheRepository,
     private val storeFactory: CoffeeDrinksDataStoreFactory,
     private val userRepository: UserRepository
@@ -30,7 +30,7 @@ class CoffeeDrinksDataRepository(
                 return@onErrorResumeNext Single.error(error)
             }
             .retry(REPEAT_REQUEST_COUNT)
-            .map { it.map { entity -> coffeeMapper.mapFromEntity(entity) } }
+            .map { it.map { entity -> coffeeDrinkDataMapper.mapFromEntity(entity) } }
     }
 
     override fun getCoffeeDrinksByName(name: String): Single<List<CoffeeDrink>> {
@@ -47,7 +47,7 @@ class CoffeeDrinksDataRepository(
                 return@onErrorResumeNext Single.error(error)
             }
             .retry(REPEAT_REQUEST_COUNT)
-            .map { coffeeMapper.mapFromEntity(it) }
+            .map { coffeeDrinkDataMapper.mapFromEntity(it) }
     }
 
     override fun addCoffeeDrinkToFavourites(coffeeId: Long): Single<CoffeeDrink> {
@@ -60,7 +60,7 @@ class CoffeeDrinksDataRepository(
                 return@onErrorResumeNext Single.error(error)
             }
             .retry(REPEAT_REQUEST_COUNT)
-            .map { coffeeMapper.mapFromEntity(it) }
+            .map { coffeeDrinkDataMapper.mapFromEntity(it) }
     }
 
     override fun removeCoffeeDrinkFromFavourites(coffeeId: Long): Single<CoffeeDrink> {
@@ -73,6 +73,6 @@ class CoffeeDrinksDataRepository(
                 return@onErrorResumeNext Single.error(error)
             }
             .retry(REPEAT_REQUEST_COUNT)
-            .map { coffeeMapper.mapFromEntity(it) }
+            .map { coffeeDrinkDataMapper.mapFromEntity(it) }
     }
 }

--- a/data/src/main/java/com/alexzh/data/MapDataProvider.kt
+++ b/data/src/main/java/com/alexzh/data/MapDataProvider.kt
@@ -1,16 +1,16 @@
 package com.alexzh.data
 
-import com.alexzh.data.mapper.MapMapper
+import com.alexzh.data.mapper.MapDataMapper
 import com.alexzh.data.repository.PreferencesRepository
 import com.alexzh.imbarista.domain.MapProvider
 import com.alexzh.imbarista.domain.model.Map
 
 class MapDataProvider(
     private val preferencesRepository: PreferencesRepository,
-    private val mapMapper: MapMapper
+    private val mapDataMapper: MapDataMapper
 ) : MapProvider {
 
     override fun getMap(): Map {
-        return mapMapper.mapFromEntity(preferencesRepository.getMapProvider())
+        return mapDataMapper.mapFromEntity(preferencesRepository.getMapProvider())
     }
 }

--- a/data/src/main/java/com/alexzh/data/NearMeCafeDataRepository.kt
+++ b/data/src/main/java/com/alexzh/data/NearMeCafeDataRepository.kt
@@ -1,6 +1,6 @@
 package com.alexzh.data
 
-import com.alexzh.data.mapper.CafeMapper
+import com.alexzh.data.mapper.CafeDataMapper
 import com.alexzh.data.store.CafeDataStore
 import com.alexzh.imbarista.domain.model.Cafe
 import com.alexzh.imbarista.domain.repository.NearMeCafeRepository
@@ -8,7 +8,7 @@ import io.reactivex.Single
 
 class NearMeCafeDataRepository(
     private val cafeDataStore: CafeDataStore,
-    private val cafeMapper: CafeMapper
+    private val cafeDataMapper: CafeDataMapper
 ) : NearMeCafeRepository {
 
     override fun getCafes(
@@ -16,6 +16,6 @@ class NearMeCafeDataRepository(
         currentLongitude: Double
     ): Single<List<Cafe>> {
         return cafeDataStore.getCafes(currentLatitude, currentLongitude)
-            .map { cafes -> cafes.map { cafeMapper.mapFromEntity(it) } }
+            .map { cafes -> cafes.map { cafeDataMapper.mapFromEntity(it) } }
     }
 }

--- a/data/src/main/java/com/alexzh/data/UserDataRepository.kt
+++ b/data/src/main/java/com/alexzh/data/UserDataRepository.kt
@@ -1,7 +1,7 @@
 package com.alexzh.data
 
-import com.alexzh.data.mapper.SessionMapper
-import com.alexzh.data.mapper.UserMapper
+import com.alexzh.data.mapper.SessionDataMapper
+import com.alexzh.data.mapper.UserDataMapper
 import com.alexzh.data.model.HttpDataException
 import com.alexzh.data.repository.PreferencesRepository
 import com.alexzh.data.store.UserDataStore
@@ -13,8 +13,8 @@ import io.reactivex.Single
 
 class UserDataRepository(
     private val userDataStore: UserDataStore,
-    private val userMapper: UserMapper,
-    private val sessionMapper: SessionMapper,
+    private val userDataMapper: UserDataMapper,
+    private val sessionDataMapper: SessionDataMapper,
     private val preferencesRepository: PreferencesRepository
 ) : UserRepository {
 
@@ -25,7 +25,7 @@ class UserDataRepository(
     override fun createAccount(name: String, email: String, password: String): Single<User> {
         return userDataStore.createAccount(name, email, password)
             .retry(REPEAT_REQUEST_COUNT)
-            .map { userMapper.mapFromEntity(it) }
+            .map { userDataMapper.mapFromEntity(it) }
     }
 
     override fun logIn(email: String, password: String): Single<Session> {
@@ -35,7 +35,7 @@ class UserDataRepository(
                 Single.just(it)
             }
             .retry(REPEAT_REQUEST_COUNT)
-            .map { sessionMapper.mapFromEntity(it) }
+            .map { sessionDataMapper.mapFromEntity(it) }
     }
 
     override fun logOut(): Completable {
@@ -53,7 +53,7 @@ class UserDataRepository(
                 Single.just(it)
             }
             .retry(REPEAT_REQUEST_COUNT)
-            .map { sessionMapper.mapFromEntity(it) }
+            .map { sessionDataMapper.mapFromEntity(it) }
     }
 
     override fun getCurrentUserInfo(): Single<User> {
@@ -66,7 +66,7 @@ class UserDataRepository(
                 return@onErrorResumeNext Single.error(error)
             }
             .retry(REPEAT_REQUEST_COUNT)
-            .map { userMapper.mapFromEntity(it) }
+            .map { userDataMapper.mapFromEntity(it) }
     }
 
     override fun getExistingSession(): Single<Session> {
@@ -74,7 +74,7 @@ class UserDataRepository(
 
         return if (session.sessionId != -1L) {
             Single.just(preferencesRepository.getSessionInfo())
-                .map { sessionMapper.mapFromEntity(it) }
+                .map { sessionDataMapper.mapFromEntity(it) }
         } else {
             Single.error(IllegalArgumentException("No data stored in shared preferences"))
         }

--- a/data/src/main/java/com/alexzh/data/mapper/CafeDataMapper.kt
+++ b/data/src/main/java/com/alexzh/data/mapper/CafeDataMapper.kt
@@ -3,7 +3,7 @@ package com.alexzh.data.mapper
 import com.alexzh.data.model.CafeEntity
 import com.alexzh.imbarista.domain.model.Cafe
 
-class CafeMapper : EntityMapper<CafeEntity, Cafe> {
+class CafeDataMapper : EntityMapper<CafeEntity, Cafe> {
 
     override fun mapFromEntity(entity: CafeEntity): Cafe {
         return Cafe(

--- a/data/src/main/java/com/alexzh/data/mapper/CoffeeDrinkDataMapper.kt
+++ b/data/src/main/java/com/alexzh/data/mapper/CoffeeDrinkDataMapper.kt
@@ -3,7 +3,7 @@ package com.alexzh.data.mapper
 import com.alexzh.data.model.CoffeeDrinkEntity
 import com.alexzh.imbarista.domain.model.CoffeeDrink
 
-class CoffeeMapper : EntityMapper<CoffeeDrinkEntity, CoffeeDrink> {
+class CoffeeDrinkDataMapper : EntityMapper<CoffeeDrinkEntity, CoffeeDrink> {
 
     override fun mapFromEntity(entity: CoffeeDrinkEntity): CoffeeDrink {
         return CoffeeDrink(

--- a/data/src/main/java/com/alexzh/data/mapper/MapDataMapper.kt
+++ b/data/src/main/java/com/alexzh/data/mapper/MapDataMapper.kt
@@ -3,7 +3,7 @@ package com.alexzh.data.mapper
 import com.alexzh.data.model.MapEntity
 import com.alexzh.imbarista.domain.model.Map
 
-class MapMapper : EntityMapper<MapEntity, Map> {
+class MapDataMapper : EntityMapper<MapEntity, Map> {
 
     override fun mapFromEntity(entity: MapEntity): Map {
         return Map.valueOf(entity.name)

--- a/data/src/main/java/com/alexzh/data/mapper/SessionDataMapper.kt
+++ b/data/src/main/java/com/alexzh/data/mapper/SessionDataMapper.kt
@@ -3,7 +3,8 @@ package com.alexzh.data.mapper
 import com.alexzh.data.model.SessionEntity
 import com.alexzh.imbarista.domain.model.Session
 
-class SessionMapper : EntityMapper<SessionEntity, Session> {
+class SessionDataMapper : EntityMapper<SessionEntity, Session> {
+
     override fun mapFromEntity(entity: SessionEntity): Session {
         return Session(
             entity.sessionId,

--- a/data/src/main/java/com/alexzh/data/mapper/UserAlreadyExistExceptionDataMapper.kt
+++ b/data/src/main/java/com/alexzh/data/mapper/UserAlreadyExistExceptionDataMapper.kt
@@ -3,7 +3,7 @@ package com.alexzh.data.mapper
 import com.alexzh.data.model.UserAlreadyExistDataException
 import com.alexzh.imbarista.domain.model.UserAlreadyExistException
 
-class UserAlreadyExistExceptionMapper : ExceptionMapper<UserAlreadyExistDataException, UserAlreadyExistException> {
+class UserAlreadyExistExceptionDataMapper : ExceptionMapper<UserAlreadyExistDataException, UserAlreadyExistException> {
 
     override fun mapFromEntityException(entity: UserAlreadyExistDataException): UserAlreadyExistException {
         return UserAlreadyExistException()

--- a/data/src/main/java/com/alexzh/data/mapper/UserDataMapper.kt
+++ b/data/src/main/java/com/alexzh/data/mapper/UserDataMapper.kt
@@ -3,7 +3,7 @@ package com.alexzh.data.mapper
 import com.alexzh.data.model.UserEntity
 import com.alexzh.imbarista.domain.model.User
 
-class UserMapper : EntityMapper<UserEntity, User> {
+class UserDataMapper : EntityMapper<UserEntity, User> {
     override fun mapFromEntity(entity: UserEntity): User {
         return User(
             entity.id,

--- a/data/src/main/java/com/alexzh/data/store/UserRemoteDataStore.kt
+++ b/data/src/main/java/com/alexzh/data/store/UserRemoteDataStore.kt
@@ -1,6 +1,6 @@
 package com.alexzh.data.store
 
-import com.alexzh.data.mapper.UserAlreadyExistExceptionMapper
+import com.alexzh.data.mapper.UserAlreadyExistExceptionDataMapper
 import com.alexzh.data.model.SessionEntity
 import com.alexzh.data.model.UserAlreadyExistDataException
 import com.alexzh.data.model.UserEntity
@@ -11,14 +11,14 @@ import io.reactivex.Single
 class UserRemoteDataStore(
     private val repository: UserRemoteRepository,
     private val preferencesRepository: PreferencesRepository,
-    private val userAlreadyExistExceptionMapper: UserAlreadyExistExceptionMapper
+    private val userAlreadyExistExceptionDataMapper: UserAlreadyExistExceptionDataMapper
 ) : UserDataStore {
 
     override fun createAccount(name: String, email: String, password: String): Single<UserEntity> {
         return repository.createAccount(name, email, password)
             .onErrorResumeNext { error ->
                 if (error is UserAlreadyExistDataException) {
-                    return@onErrorResumeNext Single.error(userAlreadyExistExceptionMapper.mapFromEntityException(error))
+                    return@onErrorResumeNext Single.error(userAlreadyExistExceptionDataMapper.mapFromEntityException(error))
                 }
                 return@onErrorResumeNext Single.error(error)
             }

--- a/data/src/test/java/com/alexzh/data/CoffeeDrinksDataRepositoryTest.kt
+++ b/data/src/test/java/com/alexzh/data/CoffeeDrinksDataRepositoryTest.kt
@@ -1,6 +1,6 @@
 package com.alexzh.data
 
-import com.alexzh.data.mapper.CoffeeMapper
+import com.alexzh.data.mapper.CoffeeDrinkDataMapper
 import com.alexzh.data.model.CoffeeDrinkEntity
 import com.alexzh.data.repository.CoffeeDrinksCacheRepository
 import com.alexzh.data.store.CoffeeDrinksDataStoreFactory
@@ -18,7 +18,7 @@ import org.junit.Test
 
 class CoffeeDrinksDataRepositoryTest {
 
-    private val mapper = mockk<CoffeeMapper>()
+    private val mapper = mockk<CoffeeDrinkDataMapper>()
     private val storeFactory = mockk<CoffeeDrinksDataStoreFactory>()
     private val cacheRepository = mockk<CoffeeDrinksCacheRepository>()
     private val remoteDataStore = mockk<CoffeeDrinksRemoteDataStore>()

--- a/data/src/test/java/com/alexzh/data/mapper/CoffeeDrinkMapperTest.kt
+++ b/data/src/test/java/com/alexzh/data/mapper/CoffeeDrinkMapperTest.kt
@@ -9,7 +9,7 @@ import org.junit.Test
 
 class CoffeeDrinkMapperTest {
 
-    private val mapper = CoffeeMapper()
+    private val mapper = CoffeeDrinkDataMapper()
 
     @Test
     fun mapFromEntityMapsDataCorrectly() {

--- a/data/src/test/java/com/alexzh/data/mapper/SessionDataMapperTest.kt
+++ b/data/src/test/java/com/alexzh/data/mapper/SessionDataMapperTest.kt
@@ -7,9 +7,9 @@ import com.alexzh.testdata.domain.GenerateDomainTestData.generateSession
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-class SessionMapperTest {
+class SessionDataMapperTest {
 
-    private val mapper = SessionMapper()
+    private val mapper = SessionDataMapper()
 
     @Test
     fun mapFromEntityToDomainModelCorrectly() {

--- a/data/src/test/java/com/alexzh/data/mapper/UserDataMapperTest.kt
+++ b/data/src/test/java/com/alexzh/data/mapper/UserDataMapperTest.kt
@@ -7,9 +7,9 @@ import com.alexzh.testdata.domain.GenerateDomainTestData.generateUser
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-class UserMapperTest {
+class UserDataMapperTest {
 
-    private val mapper = UserMapper()
+    private val mapper = UserDataMapper()
 
     @Test
     fun mapFromEntityToDomainModelCorrectly() {

--- a/mobile-ui/src/main/java/com/alexzh/imbarista/di/AppModule.kt
+++ b/mobile-ui/src/main/java/com/alexzh/imbarista/di/AppModule.kt
@@ -7,13 +7,13 @@ import com.alexzh.data.CoffeeDrinksDataRepository
 import com.alexzh.data.MapDataProvider
 import com.alexzh.data.NearMeCafeDataRepository
 import com.alexzh.data.UserDataRepository
-import com.alexzh.data.mapper.CoffeeMapper
-import com.alexzh.data.mapper.UserAlreadyExistExceptionMapper
+import com.alexzh.data.mapper.*
 import com.alexzh.data.repository.*
 import com.alexzh.data.store.*
 import com.alexzh.imbarista.cache.CoffeeDrinksCacheRepositoryImpl
 import com.alexzh.imbarista.cache.SharedPreferencesRepository
-import com.alexzh.imbarista.cache.mapper.MapMapper
+import com.alexzh.imbarista.cache.mapper.MapCacheMapper
+import com.alexzh.imbarista.cache.mapper.SessionCacheMapper
 import com.alexzh.imbarista.domain.MapProvider
 import com.alexzh.imbarista.domain.executor.PostExecutionThread
 import com.alexzh.imbarista.domain.interactor.cafe.GetNearCafeFromTomTomSource
@@ -31,6 +31,7 @@ import com.alexzh.imbarista.remote.CafeRemoteRepositoryImpl
 import com.alexzh.imbarista.remote.CoffeeDrinkRemoteRepositoryImpl
 import com.alexzh.imbarista.remote.UserRemoteRepositoryImpl
 import com.alexzh.imbarista.remote.mapper.*
+import com.alexzh.imbarista.remote.mapper.SessionRemoteMapper
 import com.alexzh.imbarista.remote.service.CoffeeDrinksServiceFactory
 import com.alexzh.imbarista.remote.service.TomTomDataSearchService
 import com.alexzh.imbarista.remote.service.TomTomSearchService
@@ -65,50 +66,63 @@ val useCaseModule = module {
 }
 
 val mapProviderModule = module {
-    factory<MapProvider> { MapDataProvider(preferencesRepository = get(), mapMapper = get()) }
+    factory<MapProvider> { MapDataProvider(preferencesRepository = get(), mapDataMapper = get()) }
     factory { MapFactory(mapProvider = get(), mapViewMapper = get()) }
 }
 
 val mapperModule = module {
-    factory { CoffeeMapper() }
-    factory { com.alexzh.imbarista.remote.mapper.CoffeeMapper() }
-    factory { SessionViewMapper() }
-    factory { UserViewMapper() }
-    factory { UserMapper() }
-    factory { com.alexzh.data.mapper.UserMapper() }
-    factory { SessionMapper() }
-    factory { com.alexzh.data.mapper.SessionMapper() }
-    factory { com.alexzh.imbarista.cache.mapper.SessionMapper() }
+    factory { CoffeeDrinkDataMapper() }
+    factory { CoffeeDrinkRemoteMapper() }
     factory { CoffeeDrinkViewMapper() }
-    factory { HttpExceptionMapper() }
-    factory { MapMapper() }
-    factory { com.alexzh.data.mapper.MapMapper() }
+
+    factory { UserRemoteMapper() }
+    factory { UserDataMapper() }
+    factory { UserViewMapper() }
+
+    factory { SessionRemoteMapper() }
+    factory { SessionCacheMapper() }
+    factory { SessionDataMapper() }
+    factory { SessionViewMapper() }
+
+    factory { MapCacheMapper() }
+    factory { MapDataMapper() }
     factory { MapViewMapper() }
-    factory { CafeMapper() }
-    factory { com.alexzh.data.mapper.CafeMapper() }
+
+    factory { CafeRemoteMapper() }
+    factory { CafeDataMapper() }
     factory { CafeViewMapper() }
-    factory { UserAlreadyExistViewExceptionMapper() }
-    factory { UserAlreadyExistExceptionMapper() }
-    factory { com.alexzh.imbarista.remote.mapper.UserAlreadyExistExceptionMapper() }
+
+    factory { HttpExceptionMapper() }
+
+    factory { UserAlreadyExistExceptionRemoteMapper() }
+    factory { UserAlreadyExistExceptionDataMapper() }
+    factory { UserAlreadyExistExceptionViewMapper() }
 }
 
 val dataModule = module {
-    factory { CoffeeDrinksServiceFactory().createCoffeeDrinksService(true) }
-    factory<CoffeeDrinksCacheRepository> { CoffeeDrinksCacheRepositoryImpl() }
-    factory<CoffeeDrinksRemoteRepository> { CoffeeDrinkRemoteRepositoryImpl(service = get(), coffeeMapper = get(), httpExceptionMapper = get()) }
-    factory { CoffeeDrinksCacheDataStore(cacheRepository = get()) }
-    factory { CoffeeDrinksRemoteDataStore(remoteRepository = get(), preferencesRepository = get()) }
-    factory { CoffeeDrinksDataStoreFactory(remoteDataStore = get(), cacheDataStore = get()) }
-    factory<CoffeeDrinksRepository> { CoffeeDrinksDataRepository(coffeeMapper = get(), cacheRepository = get(), storeFactory = get(), userRepository = get()) }
-    factory<UserRemoteRepository> { UserRemoteRepositoryImpl(service = get(), userMapper = get(), sessionMapper = get(), userAlreadyExceptionExceptionMapper = get()) }
-    factory<UserDataStore> { UserRemoteDataStore(repository = get(), preferencesRepository = get(), userAlreadyExistExceptionMapper = get()) }
+    // android
     factory<SharedPreferences> { PreferenceManager.getDefaultSharedPreferences(androidContext()) }
-    factory<PreferencesRepository> { SharedPreferencesRepository(prefs = get(), sessionMapper = get(), mapMapper = get()) }
-    single<UserRepository>(override = true) { UserDataRepository(userDataStore = get(), userMapper = get(), sessionMapper = get(), preferencesRepository = get()) }
+
+    // domain
+    factory<CoffeeDrinksRepository> { CoffeeDrinksDataRepository(coffeeDrinkDataMapper = get(), cacheRepository = get(), storeFactory = get(), userRepository = get()) }
+    single<UserRepository>(override = true) { UserDataRepository(userDataStore = get(), userDataMapper = get(), sessionDataMapper = get(), preferencesRepository = get()) }
+    factory<NearMeCafeRepository> { NearMeCafeDataRepository(cafeDataStore = get(), cafeDataMapper = get()) }
+
+    // remote
+    factory { CoffeeDrinksServiceFactory().createCoffeeDrinksService(true) }
     factory<TomTomSearchService> { TomTomDataSearchService(androidContext() as Application) }
-    factory<CafeRemoteRepository> { CafeRemoteRepositoryImpl(tomTomSearchService = get(), cafeMapper = get()) }
+
+    // data
+    factory<CafeRemoteRepository> { CafeRemoteRepositoryImpl(tomTomSearchService = get(), cafeRemoteMapper = get()) }
+    factory<CoffeeDrinksRemoteRepository> { CoffeeDrinkRemoteRepositoryImpl(service = get(), coffeeDrinkRemoteMapper = get(), httpExceptionMapper = get()) }
+    factory { CoffeeDrinksRemoteDataStore(remoteRepository = get(), preferencesRepository = get()) }
+    factory<CoffeeDrinksCacheRepository> { CoffeeDrinksCacheRepositoryImpl() }
+    factory { CoffeeDrinksCacheDataStore(cacheRepository = get()) }
+    factory { CoffeeDrinksDataStoreFactory(remoteDataStore = get(), cacheDataStore = get()) }
+    factory<UserRemoteRepository> { UserRemoteRepositoryImpl(service = get(), userRemoteMapper = get(), sessionRemoteMapper = get(), userAlreadyExceptionExceptionRemoteMapper = get()) }
+    factory<UserDataStore> { UserRemoteDataStore(repository = get(), preferencesRepository = get(), userAlreadyExistExceptionDataMapper = get()) }
+    factory<PreferencesRepository> { SharedPreferencesRepository(prefs = get(), sessionCacheMapper = get(), mapCacheMapper = get()) }
     factory<CafeDataStore> { CafeRemoteDataStore(repository = get(), preferencesRepository = get()) }
-    factory<NearMeCafeRepository> { NearMeCafeDataRepository(cafeDataStore = get(), cafeMapper = get()) }
 }
 
 val executorModule = module {

--- a/mobile-ui/src/main/java/com/alexzh/imbarista/mapper/UserAlreadyExistExceptionViewMapper.kt
+++ b/mobile-ui/src/main/java/com/alexzh/imbarista/mapper/UserAlreadyExistExceptionViewMapper.kt
@@ -3,7 +3,7 @@ package com.alexzh.imbarista.mapper
 import com.alexzh.imbarista.domain.model.UserAlreadyExistException
 import com.alexzh.imbarista.model.UserAlreadyExistViewException
 
-class UserAlreadyExistViewExceptionMapper : ExceptionMapper<UserAlreadyExistViewException, UserAlreadyExistException> {
+class UserAlreadyExistExceptionViewMapper : ExceptionMapper<UserAlreadyExistViewException, UserAlreadyExistException> {
 
     override fun mapToView(type: UserAlreadyExistException): UserAlreadyExistViewException {
         return UserAlreadyExistViewException()

--- a/mobile-ui/src/main/java/com/alexzh/imbarista/viewmodel/CreateAccountViewModel.kt
+++ b/mobile-ui/src/main/java/com/alexzh/imbarista/viewmodel/CreateAccountViewModel.kt
@@ -8,7 +8,7 @@ import com.alexzh.imbarista.domain.interactor.user.CreateAccount
 import com.alexzh.imbarista.domain.model.User
 import com.alexzh.imbarista.domain.model.UserAlreadyExistException
 import com.alexzh.imbarista.ext.isValidEmail
-import com.alexzh.imbarista.mapper.UserAlreadyExistViewExceptionMapper
+import com.alexzh.imbarista.mapper.UserAlreadyExistExceptionViewMapper
 import com.alexzh.imbarista.mapper.UserViewMapper
 import com.alexzh.imbarista.model.UserView
 import com.alexzh.imbarista.state.Resource
@@ -84,7 +84,7 @@ class CreateAccountViewModel(
 
         override fun onError(error: Throwable) {
             val newError = if (error is UserAlreadyExistException) {
-                UserAlreadyExistViewExceptionMapper().mapToView(error)
+                UserAlreadyExistExceptionViewMapper().mapToView(error)
             } else {
                 error
             }

--- a/remote/src/main/java/com/alexzh/imbarista/remote/CafeRemoteRepositoryImpl.kt
+++ b/remote/src/main/java/com/alexzh/imbarista/remote/CafeRemoteRepositoryImpl.kt
@@ -2,7 +2,7 @@ package com.alexzh.imbarista.remote
 
 import com.alexzh.data.model.CafeEntity
 import com.alexzh.data.repository.CafeRemoteRepository
-import com.alexzh.imbarista.remote.mapper.CafeMapper
+import com.alexzh.imbarista.remote.mapper.CafeRemoteMapper
 import com.alexzh.imbarista.remote.model.CafeModel
 import com.alexzh.imbarista.remote.service.TomTomSearchService
 import io.reactivex.Single
@@ -10,7 +10,7 @@ import java.lang.RuntimeException
 
 class CafeRemoteRepositoryImpl(
     private val tomTomSearchService: TomTomSearchService,
-    private val cafeMapper: CafeMapper
+    private val cafeRemoteMapper: CafeRemoteMapper
 ) : CafeRemoteRepository {
     override fun getCafes(
         currentLatitude: Double,
@@ -22,7 +22,7 @@ class CafeRemoteRepositoryImpl(
             .onErrorResumeNext { Single.error(RuntimeException(it)) }
             .map { response ->
                 response.results.map {
-                    cafeMapper.mapFromModel(
+                    cafeRemoteMapper.mapFromModel(
                         CafeModel(
                             it.poi.name,
                             it.position.latitude,

--- a/remote/src/main/java/com/alexzh/imbarista/remote/CoffeeDrinkRemoteRepositoryImpl.kt
+++ b/remote/src/main/java/com/alexzh/imbarista/remote/CoffeeDrinkRemoteRepositoryImpl.kt
@@ -2,7 +2,7 @@ package com.alexzh.imbarista.remote
 
 import com.alexzh.data.model.CoffeeDrinkEntity
 import com.alexzh.data.repository.CoffeeDrinksRemoteRepository
-import com.alexzh.imbarista.remote.mapper.CoffeeMapper
+import com.alexzh.imbarista.remote.mapper.CoffeeDrinkRemoteMapper
 import com.alexzh.imbarista.remote.mapper.HttpExceptionMapper
 import com.alexzh.imbarista.remote.model.CoffeeDrinkDataModel
 import com.alexzh.imbarista.remote.model.CoffeeDrinkFavouriteValueModel
@@ -13,7 +13,7 @@ import retrofit2.HttpException
 
 class CoffeeDrinkRemoteRepositoryImpl(
     private val service: CoffeeDrinksService,
-    private val coffeeMapper: CoffeeMapper,
+    private val coffeeDrinkRemoteMapper: CoffeeDrinkRemoteMapper,
     private val httpExceptionMapper: HttpExceptionMapper
 ) : CoffeeDrinksRemoteRepository {
 
@@ -62,6 +62,6 @@ class CoffeeDrinkRemoteRepositoryImpl(
     private fun convertCoffeeDrinkResponseToCoffeeDrinkEntities(
         response: ResponseModel<CoffeeDrinkDataModel>
     ): List<CoffeeDrinkEntity> {
-        return response.data.data.map { coffeeMapper.mapFromModel(it) }
+        return response.data.data.map { coffeeDrinkRemoteMapper.mapFromModel(it) }
     }
 }

--- a/remote/src/main/java/com/alexzh/imbarista/remote/UserRemoteRepositoryImpl.kt
+++ b/remote/src/main/java/com/alexzh/imbarista/remote/UserRemoteRepositoryImpl.kt
@@ -3,9 +3,9 @@ package com.alexzh.imbarista.remote
 import com.alexzh.data.model.SessionEntity
 import com.alexzh.data.model.UserEntity
 import com.alexzh.data.repository.UserRemoteRepository
-import com.alexzh.imbarista.remote.mapper.SessionMapper
-import com.alexzh.imbarista.remote.mapper.UserAlreadyExistExceptionMapper
-import com.alexzh.imbarista.remote.mapper.UserMapper
+import com.alexzh.imbarista.remote.mapper.SessionRemoteMapper
+import com.alexzh.imbarista.remote.mapper.UserAlreadyExistExceptionRemoteMapper
+import com.alexzh.imbarista.remote.mapper.UserRemoteMapper
 import com.alexzh.imbarista.remote.model.RefreshTokenModel
 import com.alexzh.imbarista.remote.model.ResponseModel
 import com.alexzh.imbarista.remote.model.UserModel
@@ -15,9 +15,9 @@ import retrofit2.HttpException
 
 class UserRemoteRepositoryImpl(
     private val service: CoffeeDrinksService,
-    private val userMapper: UserMapper,
-    private val sessionMapper: SessionMapper,
-    private val userAlreadyExceptionExceptionMapper: UserAlreadyExistExceptionMapper
+    private val userRemoteMapper: UserRemoteMapper,
+    private val sessionRemoteMapper: SessionRemoteMapper,
+    private val userAlreadyExceptionExceptionRemoteMapper: UserAlreadyExistExceptionRemoteMapper
 ) : UserRemoteRepository {
 
     override fun createAccount(name: String, email: String, password: String): Single<UserEntity> {
@@ -28,12 +28,12 @@ class UserRemoteRepositoryImpl(
         )
         return service.createUser(user)
             .onErrorResumeNext { handleCreateAccountError(it) }
-            .map { userMapper.mapFromModel(it.data) }
+            .map { userRemoteMapper.mapFromModel(it.data) }
     }
 
     private fun handleCreateAccountError(error: Throwable): Single<ResponseModel<UserModel>> {
         if (error is HttpException && error.code() == 409) {
-            return Single.error(userAlreadyExceptionExceptionMapper.mapToDataException(error))
+            return Single.error(userAlreadyExceptionExceptionRemoteMapper.mapToDataException(error))
         }
         return Single.error(error)
     }
@@ -44,21 +44,21 @@ class UserRemoteRepositoryImpl(
             password = password
         )
         return service.logIn(user)
-            .map { sessionMapper.mapFromModel(it.data) }
+            .map { sessionRemoteMapper.mapFromModel(it.data) }
     }
 
     override fun logOut(sessionId: Long, accessToken: String): Single<SessionEntity> {
         return service.logOut(sessionId, accessToken)
-            .map { sessionMapper.mapFromModel(it.data) }
+            .map { sessionRemoteMapper.mapFromModel(it.data) }
     }
 
     override fun refreshToken(sessionId: Long, accessToken: String, refreshToken: String): Single<SessionEntity> {
         return service.refreshToken(sessionId, accessToken, RefreshTokenModel(refreshToken))
-            .map { sessionMapper.mapFromModel(it.data) }
+            .map { sessionRemoteMapper.mapFromModel(it.data) }
     }
 
     override fun getCurrentUser(accessToken: String): Single<UserEntity> {
         return service.getCurrentUser(accessToken)
-            .map { userMapper.mapFromModel(it.data) }
+            .map { userRemoteMapper.mapFromModel(it.data) }
     }
 }

--- a/remote/src/main/java/com/alexzh/imbarista/remote/mapper/CafeRemoteMapper.kt
+++ b/remote/src/main/java/com/alexzh/imbarista/remote/mapper/CafeRemoteMapper.kt
@@ -3,7 +3,7 @@ package com.alexzh.imbarista.remote.mapper
 import com.alexzh.data.model.CafeEntity
 import com.alexzh.imbarista.remote.model.CafeModel
 
-class CafeMapper : ModelMapper<CafeModel, CafeEntity> {
+class CafeRemoteMapper : ModelMapper<CafeModel, CafeEntity> {
 
     override fun mapFromModel(model: CafeModel): CafeEntity {
         return CafeEntity(

--- a/remote/src/main/java/com/alexzh/imbarista/remote/mapper/CoffeeDrinkRemoteMapper.kt
+++ b/remote/src/main/java/com/alexzh/imbarista/remote/mapper/CoffeeDrinkRemoteMapper.kt
@@ -3,10 +3,9 @@ package com.alexzh.imbarista.remote.mapper
 import com.alexzh.data.model.CoffeeDrinkEntity
 import com.alexzh.imbarista.remote.model.CoffeeDrinkModel
 
-class CoffeeMapper : ModelMapper<CoffeeDrinkModel, CoffeeDrinkEntity> {
+class CoffeeDrinkRemoteMapper : ModelMapper<CoffeeDrinkModel, CoffeeDrinkEntity> {
 
     override fun mapFromModel(model: CoffeeDrinkModel): CoffeeDrinkEntity {
-
         return CoffeeDrinkEntity(
             model.id,
             model.name,

--- a/remote/src/main/java/com/alexzh/imbarista/remote/mapper/SessionRemoteMapper.kt
+++ b/remote/src/main/java/com/alexzh/imbarista/remote/mapper/SessionRemoteMapper.kt
@@ -3,7 +3,7 @@ package com.alexzh.imbarista.remote.mapper
 import com.alexzh.data.model.SessionEntity
 import com.alexzh.imbarista.remote.model.SessionModel
 
-class SessionMapper : ModelMapper<SessionModel, SessionEntity> {
+class SessionRemoteMapper : ModelMapper<SessionModel, SessionEntity> {
 
     override fun mapFromModel(model: SessionModel): SessionEntity {
         return SessionEntity(

--- a/remote/src/main/java/com/alexzh/imbarista/remote/mapper/UserAlreadyExistExceptionRemoteMapper.kt
+++ b/remote/src/main/java/com/alexzh/imbarista/remote/mapper/UserAlreadyExistExceptionRemoteMapper.kt
@@ -3,7 +3,7 @@ package com.alexzh.imbarista.remote.mapper
 import com.alexzh.data.model.UserAlreadyExistDataException
 import retrofit2.HttpException
 
-class UserAlreadyExistExceptionMapper : ExceptionMapper<HttpException, UserAlreadyExistDataException> {
+class UserAlreadyExistExceptionRemoteMapper : ExceptionMapper<HttpException, UserAlreadyExistDataException> {
 
     override fun mapToDataException(remoteException: HttpException): UserAlreadyExistDataException {
         return UserAlreadyExistDataException()

--- a/remote/src/main/java/com/alexzh/imbarista/remote/mapper/UserRemoteMapper.kt
+++ b/remote/src/main/java/com/alexzh/imbarista/remote/mapper/UserRemoteMapper.kt
@@ -3,7 +3,7 @@ package com.alexzh.imbarista.remote.mapper
 import com.alexzh.data.model.UserEntity
 import com.alexzh.imbarista.remote.model.UserModel
 
-class UserMapper : ModelMapper<UserModel, UserEntity> {
+class UserRemoteMapper : ModelMapper<UserModel, UserEntity> {
 
     override fun mapFromModel(model: UserModel): UserEntity {
         return UserEntity(

--- a/remote/src/test/java/com/alexzh/imbarista/remote/CoffeeDrinkRemoteRepositoryImplTest.kt
+++ b/remote/src/test/java/com/alexzh/imbarista/remote/CoffeeDrinkRemoteRepositoryImplTest.kt
@@ -1,7 +1,7 @@
 package com.alexzh.imbarista.remote
 
 import com.alexzh.data.model.CoffeeDrinkEntity
-import com.alexzh.imbarista.remote.mapper.CoffeeMapper
+import com.alexzh.imbarista.remote.mapper.CoffeeDrinkRemoteMapper
 import com.alexzh.imbarista.remote.model.CoffeeDrinkDataModel
 import com.alexzh.imbarista.remote.model.CoffeeDrinkFavouriteValueModel
 import com.alexzh.imbarista.remote.model.CoffeeDrinkModel
@@ -21,7 +21,7 @@ import org.junit.Test
 class CoffeeDrinkRemoteRepositoryImplTest {
 
     private val service = mockk<CoffeeDrinksService>()
-    private val coffeeMapper = mockk<CoffeeMapper>()
+    private val coffeeMapper = mockk<CoffeeDrinkRemoteMapper>()
     private val httpExceptionMapper = mockk<HttpExceptionMapper>()
 
     private val repository = CoffeeDrinkRemoteRepositoryImpl(service, coffeeMapper, httpExceptionMapper)

--- a/remote/src/test/java/com/alexzh/imbarista/remote/UserRemoteRepositoryImplTest.kt
+++ b/remote/src/test/java/com/alexzh/imbarista/remote/UserRemoteRepositoryImplTest.kt
@@ -2,8 +2,8 @@ package com.alexzh.imbarista.remote
 
 import com.alexzh.data.model.SessionEntity
 import com.alexzh.data.model.UserEntity
-import com.alexzh.imbarista.remote.mapper.SessionMapper
-import com.alexzh.imbarista.remote.mapper.UserMapper
+import com.alexzh.imbarista.remote.mapper.SessionRemoteMapper
+import com.alexzh.imbarista.remote.mapper.UserRemoteMapper
 import com.alexzh.imbarista.remote.model.ResponseModel
 import com.alexzh.imbarista.remote.model.SessionModel
 import com.alexzh.imbarista.remote.model.UserModel
@@ -23,8 +23,8 @@ import org.junit.Test
 class UserRemoteRepositoryImplTest {
 
     private val service = mockk<CoffeeDrinksService>()
-    private val userMapper = mockk<UserMapper>()
-    private val sessionMapper = mockk<SessionMapper>()
+    private val userMapper = mockk<UserRemoteMapper>()
+    private val sessionMapper = mockk<SessionRemoteMapper>()
 
     private val repository = UserRemoteRepositoryImpl(service, userMapper, sessionMapper)
 

--- a/remote/src/test/java/com/alexzh/imbarista/remote/mapper/CoffeeDrinkMapperTest.kt
+++ b/remote/src/test/java/com/alexzh/imbarista/remote/mapper/CoffeeDrinkMapperTest.kt
@@ -8,7 +8,7 @@ import org.junit.Test
 
 class CoffeeDrinkMapperTest {
 
-    private val mapper = CoffeeMapper()
+    private val mapper = CoffeeDrinkRemoteMapper()
 
     @Test
     fun mapFromModelWithOneIngredientMapsDataCorrectly() {

--- a/remote/src/test/java/com/alexzh/imbarista/remote/mapper/SessionRemoteMapperTest.kt
+++ b/remote/src/test/java/com/alexzh/imbarista/remote/mapper/SessionRemoteMapperTest.kt
@@ -6,9 +6,9 @@ import com.alexzh.imbarista.commonandroidtestdata.remote.GenerateRemoteTestData.
 import org.junit.Assert
 import org.junit.Test
 
-class SessionMapperTest {
+class SessionRemoteMapperTest {
 
-    private val mapper = SessionMapper()
+    private val mapper = SessionRemoteMapper()
 
     @Test
     fun mapFromModelMapsDataCorrectly() {

--- a/remote/src/test/java/com/alexzh/imbarista/remote/mapper/UserRemoteMapperTest.kt
+++ b/remote/src/test/java/com/alexzh/imbarista/remote/mapper/UserRemoteMapperTest.kt
@@ -6,9 +6,9 @@ import com.alexzh.imbarista.commonandroidtestdata.remote.GenerateRemoteTestData.
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-class UserMapperTest {
+class UserRemoteMapperTest {
 
-    private val mapper = UserMapper()
+    private val mapper = UserRemoteMapper()
 
     @Test
     fun mapFromModelMapsDataCorrectly() {


### PR DESCRIPTION
* Renamed MapMapper to MapCacheMapper, SessionMapper to SessionCacheMapper classes in cache module;
* Renamed CafeMapper to CafeDataMapper, CoffeeMapper to CoffeeDrinkDataMapper, MapMapper to MapDataMapper, SessionMapper to SessionDataMapper, UserAlreadyExistExceptionMapper to UserAlreadyExistExceptionDataMapper, UserMapper to UserDataMapper classes in data module;
Renamed CafeMapper to CafeRemoteMapper, CoffeeMapper to CoffeeDrinkRemoteMapper, SessionMapper to SessionRemoteMapper, UserAlreadyExistExceptionMapper to UserAlreadyExistExceptionRemoteMapper, UserMapper to UserRemoteMapper classes in remote module;
* Renamed UserAlreadyExistViewExceptionMapper to UserAlreadyExistExceptionViewMapper class in mobile-ui module;
* Updated and formatted definitions of dependencies in AppModule.kt file